### PR TITLE
Login via email

### DIFF
--- a/ziggurat_foundations/ext/pyramid/sign_in.py
+++ b/ziggurat_foundations/ext/pyramid/sign_in.py
@@ -84,12 +84,18 @@ class ZigguratSignInProvider(object):
         came_from = request.params.get(self.signin_came_from_key, '/')
         user = self.UserModel.by_user_name(
             request.params.get(self.signin_username_key))
+        if user == None:
+            # if no result, test to see if email exists
+            user = self.UserModel.by_email(
+                request.params.get(self.signin_username_key))
         if user:
             password = request.params.get(self.signin_password_key)
             if user.check_password(password):
                 headers = pyramid.security.remember(request, user.id)
                 return ZigguratSignInSuccess(headers=headers,
                                              came_from=came_from, user=user)
+
+
         headers = pyramid.security.forget(request)
         return ZigguratSignInBadAuth(headers=headers, came_from=came_from)
 

--- a/ziggurat_foundations/models.py
+++ b/ziggurat_foundations/models.py
@@ -349,6 +349,16 @@ class UserMixin(BaseModel):
         return query.first()
 
     @classmethod
+    def by_email(cls, email, db_session=None):
+        """ fetch user by email """
+        db_session = get_db_session(db_session)
+        query = db_session.query(cls)
+        query = query.filter(sa.func.lower(cls.email) ==
+                             (email or '').lower())
+        query = query.options(sa.orm.eagerload('groups'))
+        return query.first()
+
+    @classmethod
     def by_user_name_and_security_code(cls, user_name, security_code,
                                        db_session=None):
         """ fetch user objects by user name and security code"""


### PR DESCRIPTION
Added a few lines, if there is no user value returned upon signin when looking up the username, then try the email address. Instead of having two separate configurations for login via email or username, this combines the both.

Was asked twice this week on two different projects to make this change, hence me submitting the PR, nothing major, but a nice improvement :-)
