### PR TITLE
fix travis for bcrypt with pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ notifications:
 python:
   - "3.3"
   - "3.4"
+  - "3.5"
 
 matrix:
   include:
@@ -22,16 +23,18 @@ matrix:
       env: RSTCHECK=1
 
     - python: "pypy"
-      env: PASSLIB_BUILTIN_BCRYPT="enabled"
+      env: BCRYPT="enabled"
 
     - python: "pypy3"
-      env: PASSLIB_BUILTIN_BCRYPT="enabled"
+      env: BCRYPT="enabled"
 
 install:
  - pip install flake8 rstcheck
 
 script:
   - python setup.py develop
+  - if [ -n "$BCRYPT" ]; then pip uninstall bcrypt -y; fi
+  - if [ -n "$BCRYPT" ]; then pip install py-bcrypt; fi
   - py.test ziggurat_foundations/tests.py
 
   # flake8 and rstcheck


### PR DESCRIPTION
I install ``bcrypt`` at locally in my virtualenv with ``pypy`` and it works correctly.
I did next steps:
```bash
$ sudo apt-get install pypy-dev
$ python setup.py develop
```
and
```
 $  pip list
You are using pip version 7.0.1, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
alembic (0.8.2)
cffi (1.3.0)
greenlet (0.4.7)
Mako (1.0.2)
MarkupSafe (0.23)
paginate (0.5)
paginate-sqlalchemy (0.2.0)
passlib (1.6.5)
pip (7.0.1)
py (1.4.30)
pytest (2.8.2)
python-editor (0.4)
readline (6.2.4.1)
setuptools (16.0)
six (1.10.0)
SQLAlchemy (1.0.8)
wheel (0.24.0)
ziggurat-foundations (0.6.1, /home/uralbash/Projects/package/ziggurat_foundations)
```

It's work very well for me, but the same steps not working on ``travis-ci``. I see ``bcrypt`` in ``pip list`` on travis build, but ``passlib`` say to me ``E               MissingBackendError: no bcrypt backends available -- recommend you install one (e.g. 'pip install bcrypt')`` it's goddamn! I don't know why this is happening!

Therefore, I made an alternative solution of this problem.  passlib says that can be used not only ``bcrypt`` (https://pythonhosted.org/passlib/lib/passlib.hash.bcrypt.html#index-0).  For ``pypy`` I installing ``py-bcrypt`` and it works too fast.