### PR TITLE
ExternalIdentityMixin missing mysql_engine

### DIFF
--- a/ziggurat_foundations/models/external_identity.py
+++ b/ziggurat_foundations/models/external_identity.py
@@ -7,6 +7,8 @@ from .base import get_db_session
 
 class ExternalIdentityMixin(BaseModel):
 
+    __table_args__ = {'mysql_engine': 'InnoDB', 'mysql_charset': 'utf8'}
+
     _ziggurat_service = ExternalIdentityService
 
     @declared_attr


### PR DESCRIPTION
ExternalIdentityMixin doesn't have __table_args__ declaring the mysql_engine like the other models do and as such SQLAlchemy create_all() fails with the error "Cannot add foreign key constraint". Adding the line in the overridden class for ziggurat_model_init fixed it for me.