### PR TITLE
fix script_location in docs to show a placeholder value

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -43,7 +43,7 @@ First you will need to create alembic.ini file with following contents:
 .. code-block:: ini
 
     [alembic]
-    script_location = ziggurat_foundations:migrations
+    script_location = %(here)s/alembic
     sqlalchemy.url = driver://user:pass@host/dbname
 
     [loggers]


### PR DESCRIPTION
 instead of ziggurat_foundation.migrations which is needed only for development