### PR TITLE
Typo in services/resource.py line 225 - 'GroupResourcePermission' has no attribute 'perm_id'

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,3 +43,4 @@ Contributors:
 * Arian Maykon de Araújo Diógenes (arianmaykon) 2016-04-19
 * Edward Arghiroiu (themightyonyx) 2015-11-13
 * Łukasz Bołdys (utek) 2013-11-22
+* Christian Benke (peletiah) 2017-02-19

--- a/ziggurat_foundations/models/services/resource.py
+++ b/ziggurat_foundations/models/services/resource.py
@@ -222,7 +222,7 @@ class ResourceService(BaseService):
         query = query.filter(
             cls.models_proxy.GroupResourcePermission.group_id == group_id)
         query = query.filter(
-            cls.models_proxy.GroupResourcePermission.perm_id == perm_name)
+            cls.models_proxy.GroupResourcePermission.perm_name == perm_name)
         query = query.filter(
             cls.models_proxy.GroupResourcePermission.resource_id == resource_id)
         return query.first()


### PR DESCRIPTION
This particular function hasn't seen much use yet I guess...