### PR TITLE
change set_request_property (deprecated) to add_request_method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ziggurat_foundations.egg-info
 venv*
 *.pyc
 .idea
+.eggs

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,3 +39,4 @@ Contributors:
 * Łukasz Bołdys (utek) 2013-11-22
 * Christian Benke (peletiah) 2017-02-19
 * René Jochum (pcdummy) 2018-02-13
+* Francis Charette Migneault (fmigneault) 2019-02-07

--- a/ziggurat_foundations/ext/pyramid/get_user.py
+++ b/ziggurat_foundations/ext/pyramid/get_user.py
@@ -44,4 +44,4 @@ def includeme(config):
             return UserService.by_id(userid, db_session=db_session)
 
     # add in request.user function
-    config.set_request_property(get_user, "user", reify=True)
+    config.add_request_method(get_user, "user", reify=True, property=True)


### PR DESCRIPTION
`set_request_property` is deprecated since pyramid 1.5 but got removed only recently in 1.10
replace by the equivalent `add_request_method` which is available since 1.4

https://github.com/Pylons/pyramid/blob/9e3aeb68adc4a9b685a5d8c92c04ecdeba973143/pyramid/config/factories.py#L217-L229

