### PR TITLE
adding overlaps to suppress sqlalchemy warnings

### DIFF
--- a/ziggurat_foundations/models/group.py
+++ b/ziggurat_foundations/models/group.py
@@ -56,7 +56,7 @@ class GroupMixin(BaseModel):
         """ dynamic relationship for users belonging to this group
             one can use filter """
         return sa.orm.relationship(
-            "User", secondary="users_groups", order_by="User.user_name", lazy="dynamic"
+            "User", secondary="users_groups", order_by="User.user_name", lazy="dynamic", overlaps="groups,users"
         )
 
     @declared_attr
@@ -107,6 +107,7 @@ class GroupMixin(BaseModel):
             passive_deletes=True,
             passive_updates=True,
             lazy="dynamic",
+            overlaps="owner_group,resources"
         )
 
     @sa.orm.validates("permissions")

--- a/ziggurat_foundations/models/resource.py
+++ b/ziggurat_foundations/models/resource.py
@@ -92,6 +92,7 @@ class ResourceMixin(BaseModel):
             secondary="groups_resources_permissions",
             passive_deletes=True,
             passive_updates=True,
+            overlaps="groups,resource_permissions,group_permissions",
         )
 
     @declared_attr
@@ -102,6 +103,7 @@ class ResourceMixin(BaseModel):
             secondary="users_resources_permissions",
             passive_deletes=True,
             passive_updates=True,
+            overlaps="user_permissions"
         )
 
     __mapper_args__ = {"polymorphic_on": resource_type}

--- a/ziggurat_foundations/models/user.py
+++ b/ziggurat_foundations/models/user.py
@@ -95,6 +95,7 @@ class UserMixin(BaseModel):
             lazy="dynamic",
             passive_deletes=True,
             passive_updates=True,
+            overlaps="groups,users,users_dynamic"
         )
 
     @declared_attr
@@ -120,6 +121,7 @@ class UserMixin(BaseModel):
             cascade="all, delete-orphan",
             passive_deletes=True,
             passive_updates=True,
+            overlaps="users"
         )
 
     @declared_attr


### PR DESCRIPTION
I recently upgrade sqlalchemy and started getting a few warning messages around the way the models are configured.

This was fixed by adding the "overlaps" as suggested in the below logs:

    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'Group.users_dynamic' will copy column groups.id to column users_groups.group_id, which conflicts with relationship(s): 'Group.users' (copies groups.id to users_groups.group_id), 'User.groups' (copies groups.id to users_groups.group_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="groups,users"' to the 'Group.users_dynamic' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'Group.users_dynamic' will copy column users.id to column users_groups.user_id, which conflicts with relationship(s): 'Group.users' (copies users.id to users_groups.user_id), 'User.groups' (copies users.id to users_groups.user_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="groups,users"' to the 'Group.users_dynamic' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'Group.resources_dynamic' will copy column groups.id to column resources.owner_group_id, which conflicts with relationship(s): 'Group.resources' (copies groups.id to resources.owner_group_id), 'Resource.owner_group' (copies groups.id to resources.owner_group_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="owner_group,resources"' to the 'Group.resources_dynamic' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'Resource.groups' will copy column resources.resource_id to column groups_resources_permissions.resource_id, which conflicts with relationship(s): 'Resource.group_permissions' (copies resources.resource_id to groups_resources_permissions.resource_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="group_permissions"' to the 'Resource.groups' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'Resource.groups' will copy column groups.id to column groups_resources_permissions.group_id, which conflicts with relationship(s): 'Group.resource_permissions' (copies groups.id to groups_resources_permissions.group_id), 'GroupResourcePermission.groups' (copies groups.id to groups_resources_permissions.group_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="groups,resource_permissions"' to the 'Resource.groups' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'Resource.users' will copy column resources.resource_id to column users_resources_permissions.resource_id, which conflicts with relationship(s): 'Resource.user_permissions' (copies resources.resource_id to users_resources_permissions.resource_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="user_permissions"' to the 'Resource.users' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'User.groups_dynamic' will copy column users.id to column users_groups.user_id, which conflicts with relationship(s): 'Group.users' (copies users.id to users_groups.user_id), 'Group.users_dynamic' (copies users.id to users_groups.user_id), 'User.groups' (copies users.id to users_groups.user_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="groups,users,users_dynamic"' to the 'User.groups_dynamic' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'User.groups_dynamic' will copy column groups.id to column users_groups.group_id, which conflicts with relationship(s): 'Group.users' (copies groups.id to users_groups.group_id), 'Group.users_dynamic' (copies groups.id to users_groups.group_id), 'User.groups' (copies groups.id to users_groups.group_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="groups,users,users_dynamic"' to the 'User.groups_dynamic' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
    configure_mappers()
    /home/luke/nodejs/ngx-intranet/intranet_backend_api/intranet_backend_api/intranet_models/__init__.py:12: SAWarning: relationship 'User.resource_permissions' will copy column users.id to column users_resources_permissions.user_id, which conflicts with relationship(s): 'Resource.users' (copies users.id to users_resources_permissions.user_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="users"' to the 'User.resource_permissions' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)


    