### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -92,7 +92,7 @@ Implementing ziggurat_foundations within your application
 We need to *include ALL mixins inside our application*
 and map classes together so internal methods can function properly.
 
-In order to use the mixins inside your application, you need to include the follwing code
+In order to use the mixins inside your application, you need to include the following code
 inside your models file, to extend your existing models (if following the basic pyramid tutorial):
 
 .. code-block:: python

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -33,7 +33,7 @@ only authenticated users to view:
 
 This example covers the case where every view is secured with a default "view" permission,
 and some pages require other permissions like "view_admin_panel", "create_objects" etc.
-Those permissions are appended dynamicly if authenticated user is present, and has additional
+Those permissions are appended dynamically if authenticated user is present, and has additional
 custom permissions.
 
 Example resource based pyramid context factory that can be used with url dispatch
@@ -197,7 +197,7 @@ some base imports:
 
 **ZigguratSignInSuccess context view example**
 
-Now we can provide a fuction, based off of the ZigguratSignInSuccess context
+Now we can provide a function, based off of the ZigguratSignInSuccess context
 
 .. code-block:: python
 
@@ -303,7 +303,7 @@ Or in your ini configuration file (both methods yield the same result):
                        ziggurat_foundations.ext.pyramid.get_user
 
 Then inside each pyramid view that contains a request, you can access user information
-with (the code behind this is as described in the offical pyramid cookbook, but
+with (the code behind this is as described in the official pyramid cookbook, but
 we include in within Ziggurat to make your life easier):
 
 .. code-block:: python

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -27,11 +27,11 @@ Ziggurat provides standard functions that let you:
 - Assign a user o an external identity (such as facebook/twitter)
 - Change users password and generate security codes
 - Manage the sign in/sign out process (pyramid extension)
-- Example root factory for assiginging permissions per request (for pyramid)
+- Example root factory for assigning permissions per request (for pyramid)
 
 
 Functions that we supply between those patterns allow for complex and flexible permission
-systems that are easly understandable for non-technical users, whilst at the same time
+systems that are easily understandable for non-technical users, whilst at the same time
 providing a stable base for systems coping with millions of users.
 
 Due to the fact that we supply all models as mixins, the base of Ziggurat can be very easily

--- a/ziggurat_foundations/models/__init__.py
+++ b/ziggurat_foundations/models/__init__.py
@@ -6,7 +6,7 @@ DBSession = None
 
 def groupfinder(userid, request):
     """
-    Default groupfinder implementaion for pyramid applications
+    Default groupfinder implementation for pyramid applications
 
     :param userid:
     :param request:

--- a/ziggurat_foundations/models/services/resource.py
+++ b/ziggurat_foundations/models/services/resource.py
@@ -237,7 +237,7 @@ class ResourceService(BaseService):
     @classmethod
     def by_resource_id(cls, resource_id, db_session=None):
         """
-        fetch the resouce by id
+        fetch the resource by id
 
         :param resource_id:
         :param db_session:

--- a/ziggurat_foundations/models/services/user.py
+++ b/ziggurat_foundations/models/services/user.py
@@ -95,7 +95,7 @@ class UserService(BaseService):
         :return:
         """
         # owned entities have ALL permissions so we return those resources too
-        # even without explict perms set
+        # even without explicit perms set
         # TODO: implement admin superrule perm - maybe return all apps
         db_session = get_db_session(db_session, instance)
         query = db_session.query(cls.models_proxy.Resource).distinct()


### PR DESCRIPTION
There are small typos in:
- docs/configuration.rst
- docs/integrations.rst
- docs/overview.rst
- ziggurat_foundations/models/__init__.py
- ziggurat_foundations/models/services/resource.py
- ziggurat_foundations/models/services/user.py

Fixes:
- Should read `resource` rather than `resouce`.
- Should read `official` rather than `offical`.
- Should read `implementation` rather than `implementaion`.
- Should read `function` rather than `fuction`.
- Should read `following` rather than `follwing`.
- Should read `explicit` rather than `explict`.
- Should read `easily` rather than `easly`.
- Should read `dynamically` rather than `dynamicly`.
- Should read `assigning` rather than `assiginging`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md